### PR TITLE
Update integration test code to make requests to 0.0.0.0

### DIFF
--- a/integration_test/logclient_test.go
+++ b/integration_test/logclient_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	testServerPort              = "8888"
-	testServerAddress           = "localhost:" + testServerPort
+	testServerAddress           = "0.0.0.0:" + testServerPort
 	endpointUrl                 = "ws://" + testServerAddress
 	requestedNumberOfLogEntries = 10
 	logTimestampFormat          = "2006-01-02T15:04:05.00-0700"


### PR DESCRIPTION
* In routing terms, 0.0.0.0 means the default route on the local machine
* See https://en.wikipedia.org/wiki/0.0.0.0 and https://en.wikipedia.org/wiki/Default_route

[#152120945]